### PR TITLE
Add iPad mini 5 support, fix iPhone XS support

### DIFF
--- a/arm/shared/KernelExploit/Sources/KernelExploit/offsets.swift
+++ b/arm/shared/KernelExploit/Sources/KernelExploit/offsets.swift
@@ -145,7 +145,7 @@ public struct Offsets {
             case "iPhone11,2": fallthrough
             case "iPhone11,4": fallthrough
             case "iPhone11,6": fallthrough
-            case "iPhone11,8": // iPhone XR should probably be treated like an XS
+            case "iPhone11,8", "iPad11,1": // iPhone XR should probably be treated like an XS, and iPad Mini 5 needs to be treated as an XS to work properly
                 return .iPhoneXS
                 
             case "iPhone12,1": fallthrough
@@ -529,7 +529,7 @@ public struct Offsets {
         case 5:
             // Return different offsets depending on whether or not this is an XS
             if case .iPhoneXS = device {
-                return (taskStruct: taskStruct14_4, threadStruct: threadStruct14_5_XS)
+                return (taskStruct: taskStruct14_5, threadStruct: threadStruct14_5_XS)
             } else {
                 return (taskStruct: taskStruct14_5, threadStruct: threadStruct14_5)
             }


### PR DESCRIPTION
Thanks to @akeebler1989 for finding the fix for iPhone XS (which was required for part of the iPad Mini 5 fix.)