### PR TITLE
fix missing arm64e slice from FuguKrw plugin

### DIFF
--- a/arm/iOS/Fugu14Krw/build.sh
+++ b/arm/iOS/Fugu14Krw/build.sh
@@ -8,9 +8,32 @@ do
     swiftBuild+=(-Xswiftc "$arg")
 done
 
-echo Building Fugu14Krw
+echo Building Fugu14Krw64
 echo ${swiftBuild[*]}
 ${swiftBuild[*]}
 
+mv .build/release/libFugu14Krw.dylib libFugu14Krw-64.dylib
+rm -rf .build
+
+swiftcArgs=(-sdk "`xcrun --sdk iphoneos --show-sdk-path`" -target arm64e-apple-ios14.0 -O -framework IOKit)
+
+swiftBuild=(swift build -c release -Xcc "-DIOS_BUILD" -Xcc -target -Xcc arm64e-apple-ios14.0 -Xcc -Wno-incompatible-sysroot)
+for arg in ${swiftcArgs[*]}
+do
+    swiftBuild+=(-Xswiftc "$arg")
+done
+
+echo Building Fugu14Krw64e
+echo ${swiftBuild[*]}
+${swiftBuild[*]}
+
+mv .build/release/libFugu14Krw.dylib libFugu14Krw-64e.dylib
+
+echo gonna make them kiss
+
+lipo -create libFugu14Krw-64.dylib libFugu14Krw-64e.dylib --output libFugu14Krw.dylib
+
+rm libFugu14Krw-64.dylib libFugu14Krw-64e.dylib
+
 echo Signing Fugu14Krw
-codesign -s - .build/release/libFugu14Krw.dylib
+codesign -s - libFugu14Krw.dylib

--- a/arm/iOS/jailbreakd/build.sh
+++ b/arm/iOS/jailbreakd/build.sh
@@ -15,7 +15,7 @@ echo ${swiftBuild[*]}
 ${swiftBuild[*]}
 
 echo Stripping jailbreakd
-strip -s keep .build/release/jailbreakd
+/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip -s keep .build/release/jailbreakd
 
 echo Signing jailbreakd
 codesign -s "$CODESIGN_IDENTITY" --entitlements jailbreakd.entitlements .build/release/jailbreakd


### PR DESCRIPTION
I'm guessing it's incomplete through because the point in the jailbreak that generates the trustcache for the library needs to be adjusted to include both archs. 

Edit: in case anyone is wondering why this is needed, `/usr/lib/libkrw/1_unc0ver.dylib` is a symlink to `/usr/lib/substitute-inserter.dylib` which only includes an `arm64e` arch. By default, `libFugu14Krw.dylib` only includes an `arm64` arch. 

If any users here have noticed stuff like dimentio, [fouldecrypt](https://github.com/NyaMisty/fouldecrypt/issues/6), etc. don't work correctly, you're welcome to grabbing a prebuilt version from this [link](https://github.com/LinusHenze/Fugu14/files/7576886/libFugu14Krw.zip) (which you should thank @halo_michael for) also see https://github.com/LinusHenze/Fugu14/issues/200