### PR TITLE
Fix a race condition in GUI when printing and fix malfunctioning analyticsd daemon.

### DIFF
--- a/arm/iOS/Fugu14App/Fugu14App/ContentView.swift
+++ b/arm/iOS/Fugu14App/Fugu14App/ContentView.swift
@@ -81,7 +81,9 @@ struct ContentView: View {
     }
     
     func print(_ text: String) {
-        labelText += text + "\n"
+        DispatchQueue.main.async {
+            labelText += text + "\n"
+        }
     }
     
     func doSetup() {

--- a/arm/iOS/jailbreakd/Sources/jailbreakd/UI/ContentView.swift
+++ b/arm/iOS/jailbreakd/Sources/jailbreakd/UI/ContentView.swift
@@ -91,8 +91,10 @@ struct ContentView: View {
         alreadyInstalled = access("/.Fugu14Untether", F_OK) == 0
     }
     
-    func print(_ text: String, ender: String = "\n") {
-        labelText += text + ender
+    private func print(_ text: String, ender: String = "\n") {
+        DispatchQueue.main.async {
+            labelText += text + ender
+        }
     }
     
     func launchServer(uninstall: Bool = false) -> ProcessCommunication? {

--- a/arm/iOS/jailbreakd/Sources/jailbreakd/untether/installUntether.swift
+++ b/arm/iOS/jailbreakd/Sources/jailbreakd/untether/installUntether.swift
@@ -37,7 +37,7 @@ func installSlowUntether(mountPath: String, trustcache: String, isUpdate: Bool) 
         throw UntetherInstallError.failedToLocateJailbreakd
     }
     
-    let targetUGID = 264
+    let targetUGID = 263
     let targetExePath = mountPath + "/System/Library/PrivateFrameworks/CoreAnalytics.framework/Support/analyticsd"
     let replacementExePath = "/usr/libexec/keybagd"
     
@@ -62,12 +62,12 @@ func installSlowUntether(mountPath: String, trustcache: String, isUpdate: Bool) 
     
     Logger.print("Creating container files...")
     
-    try? FileManager.default.removeItem(atPath: untetherContainerPath)
     try? FileManager.default.removeItem(atPath: untetherClFolder)
+    try? FileManager.default.removeItem(atPath: untetherContainerPath)
     
     try FileManager.default.createDirectory(atPath: untetherContainerPath, withIntermediateDirectories: true, attributes: [.ownerAccountID: targetUGID, .groupOwnerAccountID: targetUGID])
     try FileManager.default.createDirectory(atPath: untetherClFolder + "/Caches/com.apple.dyld", withIntermediateDirectories: true, attributes: [.ownerAccountID: targetUGID, .groupOwnerAccountID: targetUGID])
-    try FileManager.default.createSymbolicLink(atPath: untetherContainerPath + "/Library", withDestinationPath: untetherClFolder)
+    try? FileManager.default.createSymbolicLink(atPath: untetherContainerPath + "/Library", withDestinationPath: untetherClFolder)
     
     Logger.print("Writing JS files")
     try? FileManager.default.createDirectory(atPath: mountPath + "/.Fugu14Untether", withIntermediateDirectories: false, attributes: nil)
@@ -109,8 +109,8 @@ func installSlowUntether(mountPath: String, trustcache: String, isUpdate: Bool) 
             var nMasterPasswd = ""
             for line in lines {
                 if line.starts(with: "_analyticsd") {
-                    nMasterPasswd.append("_analyticsd:*:264:264::0:0:Haxx Daemon:" + untetherContainerPath + ":/usr/bin/false\n")
                     nMasterPasswd.append(line.replacingOccurrences(of: "_analyticsd", with: "_nanalyticsd") + "\n")
+                    nMasterPasswd.append("_analyticsd:*:263:263::0:0:Haxx Daemon:" + untetherContainerPath + ":/usr/bin/false\n")
                 } else {
                     nMasterPasswd.append(line + "\n")
                 }
@@ -126,8 +126,9 @@ func installSlowUntether(mountPath: String, trustcache: String, isUpdate: Bool) 
             var nPasswd = ""
             for line in lines {
                 if line.starts(with: "_analyticsd") {
-                    nPasswd.append("_analyticsd:*:264:264:Haxx Daemon:" + untetherContainerPath + ":/usr/bin/false\n")
                     nPasswd.append(line.replacingOccurrences(of: "_analyticsd", with: "_nanalyticsd") + "\n")
+                    nPasswd.append("_analyticsd:*:263:263:Haxx Daemon:" + untetherContainerPath + ":/usr/bin/false\n")
+                    
                 } else {
                     nPasswd.append(line + "\n")
                 }

--- a/arm/shared/KernelExploit/Sources/KernelExploit/offsets.swift
+++ b/arm/shared/KernelExploit/Sources/KernelExploit/offsets.swift
@@ -771,7 +771,7 @@ public struct Offsets {
         }
         
         switch minor {
-        case 2: fallthrough /* Doesn't work though! */
+        case 2: fallthrough 
         case 3: fallthrough
         case 4:
             return taskStruct14_4


### PR DESCRIPTION
# Fix a race condition in GUI when printing. 
And it seems the exploitation and post-exploitation work on my iPhone 12 iOS 14.2.1 without any modification. 
# Fix malfunctioning analyticsd daemon
While the patch in Fugu14 preserved the user id and $HOME by changing the name of the user `_analyticsd` to `_nanalyticsd`, it seems that some other daemon changes the owner of `/private/var/db/analyticsd` and its subdirectories to ·_analyticsd·, whose uid has changed to 264. This will cause the `_analyticsd.back` with uid 263 to not be able to read `/private/var/db/analyticsd` at all, with error: `Home directory is not setup. Waiting to see if it gets repaired...`.   
This fix is based on the following facts:
- dyld enables independent closure loading by checking the env $HOME is a subdirectory in `/private/var/mobile/Containers/Data/`.
- launchd sets the daemons' $HOME env via `getpwname_r`.
- analyticsd get its own working path via `getuid` and `getpwuid`. 
- An unknown daemon will set the owner of `/private/var/db/analyticsd` to the user name `_analyticsd`.

So if the passwd and master.passwd have the following contents, things can be easily fixed.
``` 
passwd (master.passwd is similar)
_nanalyticsd:*:263:263:Analytics Daemon:/var/db/analyticsd:/usr/bin/false
_analyticsd:*:263:263:Haxx Daemon:/private/var/mobile/Containers/Data/Fugu14Untether:/usr/bin/false
```
And then, after the system is powered on:
- launchd launches `/System/Library/LaunchDaemon/com.apple.analyticsd.plist` with username `_analyticsd` and set $HOME to /private/var/mobile/Containers/Data/Fugu14Untether based on the username. 
- Then the dyld will load the closure exploitation and the system will be jailbroken.
- The unknown daemon will set the user ID of `/private/var/db/analyticsd` to 263, based on the username `_analyticsd`.
- Then the `analyticsd.back` with the user name `_nanalyticsd` is launched, which will use the uid 263. Although there are two user with the same uid 263, it will only pick the first one by `getpwuid`. So it will use `/private/var/db/analyticsd` with the correct owner, uid 263

Then the battery detail in Settings works properly.

If you have jailbroken by Fugu14, you can try the manual steps below, or remove origin Fugu14 jailbreak modification then and use this PR to jailbreak. Restoring rootfs is a easy way, but loses all tweaks. Or manually undo all modification according "Jailbreak" section in [Fugu14 writeup](https://github.com/LinusHenze/Fugu14/blob/master/Writeup.pdf).   